### PR TITLE
Added ability to specify optional parameters

### DIFF
--- a/octoprint_gcodesystemcommands/__init__.py
+++ b/octoprint_gcodesystemcommands/__init__.py
@@ -36,7 +36,11 @@ class GCodeSystemCommands(octoprint.plugin.StartupPlugin,
 
     def hook_gcode_queuing(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
         if not gcode and cmd[:4].upper() == 'OCTO':
-            cmd_id = cmd[4:].split(' ')[0]
+            cmd_pieces = cmd[4:].split(' ', 1)
+            cmd_id = cmd_pieces[0]
+            cmd_args = ""
+            if len(cmd_pieces) > 1:
+                cmd_args = cmd_pieces[1]
 
             try:
                 cmd_line = self.command_definitions[cmd_id]
@@ -44,13 +48,13 @@ class GCodeSystemCommands(octoprint.plugin.StartupPlugin,
                 self._logger.error("No definiton found for ID %s" % cmd_id)
                 return (None,)
 
-            self._logger.debug("Command ID=%s, Command Line=%s" % (cmd_id, cmd_line))
+            self._logger.debug("Command ID=%s, Command Line=%s, Args=%s" % (cmd_id, cmd_line, cmd_args))
 
             self._logger.info("Executing command ID: %s" % cmd_id)
             comm_instance._log("Exec(GCodeSystemCommands): OCTO%s" % cmd_id)
 
             try:
-                r = os.system(cmd_line)
+                r = os.system("%s %s" % (cmd_line, cmd_args))
             except:
                 e = sys.exc_info()[0]
                 self._logger.exception("Error executing command ID %s: %s" % (cmd_id, e))

--- a/octoprint_gcodesystemcommands/static/js/gcodesystemcommands.js
+++ b/octoprint_gcodesystemcommands/static/js/gcodesystemcommands.js
@@ -15,13 +15,15 @@ $(function() {
         };
 
         self.onBeforeBinding = function () {
-            self.settings = self.global_settings.settings.plugins.gcodesystemcommands;
-            self.command_definitions(self.settings.command_definitions.slice(0));
+            self.global_settings.settings.plugins.gcodesystemcommands.command_definitions.subscribe(function() {
+                settings = self.global_settings.settings.plugins.gcodesystemcommands;
+                self.command_definitions(settings.command_definitions.slice(0));            
+            });
         };
 
         self.onSettingsBeforeSave = function () {
             self.global_settings.settings.plugins.gcodesystemcommands.command_definitions(self.command_definitions.slice(0));
-        }
+        };
 
     }
 

--- a/octoprint_gcodesystemcommands/templates/gcodesystemcommands_settings.jinja2
+++ b/octoprint_gcodesystemcommands/templates/gcodesystemcommands_settings.jinja2
@@ -1,5 +1,5 @@
 <form class="form-horizontal">
-    <h3>Command Defninitions</h3>
+    <h3>Command Definitions</h3>
     <div class="row-fluid">
         <div class="span3"><h4>G-Code</h4></div>
         <div class="span3"><h4>System</h4></div>


### PR DESCRIPTION
Added ability to specify optional parameters for the custom GCode that will be passed to the shell script

e.g.

GCode "OCTO100 12 345"
Will call "myshellscript.sh 12 345"

If no args are specified, behavior remains the same.

