### PR TITLE
Fix logging exception which is thrown if command output contains non-ASCII characters

### DIFF
--- a/octoprint_gcodesystemcommands/__init__.py
+++ b/octoprint_gcodesystemcommands/__init__.py
@@ -5,6 +5,8 @@ __author__ = "Shawn Bruce <kantlivelong@gmail.com>"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
 __copyright__ = "Copyright (C) 2017 Shawn Bruce - Released under terms of the AGPLv3 License"
 
+import six
+
 import octoprint.plugin
 import time
 import os
@@ -76,6 +78,9 @@ class GCodeSystemCommands(octoprint.plugin.StartupPlugin,
             self._logger.exception("Error executing command ID %s: %s" % (cmd_id, e))
             return (None,)
 
+        # Make sure we don't throw when logging output if it contains non-ascii characters
+        output = six.ensure_text(output, "utf-8", "ignore")
+
         self._logger.debug("Command ID %s returned: %s, output=%s" % (cmd_id, r, output))
         self._logger.info("Command ID %s returned: %s" % (cmd_id, r))
 
@@ -106,7 +111,7 @@ class GCodeSystemCommands(octoprint.plugin.StartupPlugin,
                 data[r] = None
 
         return data
-        
+
     def on_settings_save(self, data):
         octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
         self.reload_command_definitions()
@@ -119,7 +124,7 @@ class GCodeSystemCommands(octoprint.plugin.StartupPlugin,
     def get_assets(self):
         return {
             "js": ["js/gcodesystemcommands.js"]
-        } 
+        }
 
     def get_update_information(self):
         return dict(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 OctoPrint
+# six is already required by OctoPrint, but still add it here just in case
+six


### PR DESCRIPTION
This pull request fixes an exception which was thrown when command produced output which contains non-ASCII characters.

Here is an example of the error before the fix:

```bash
Traceback (most recent call last):
  File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint/util/comm.py", line 3332, in _process_command_phase
    hook_results = hook(self, phase, command, command_type, gcode, subcode=subcode, tags=tags)
  File "/home/pi/oprint/local/lib/python2.7/site-packages/octoprint_gcodesystemcommands/__init__.py", line 79, in hook_gcode_sending
    self._logger.debug("Command ID %s returned: %s, output=%s" % (cmd_id, r, output))
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc2 in position 50: ordinal not in range(128)
```

And after:

```bash
2020-04-29 20:01:23,967 - octoprint.plugins.gcodesystemcommands - DEBUG - Command ID=907, Line=/home/pi/scripts/turn-off-printer.sh, Args=None
2020-04-29 20:01:23,976 - octoprint.plugins.gcodesystemcommands - INFO - Executing command ID: 907
2020-04-29 20:01:31,713 - octoprint.plugins.gcodesystemcommands - DEBUG - Command ID 907 returned: 0, output=Power: True
USB Power: None
Temperature: 46 °C
Load power: None
WiFi LED: None
Powering on
['ok']

2020-04-29 20:01:31,714 - octoprint.plugins.gcodesystemcommands - INFO - Command ID 907 returned: 0
```


I've tested it using Python 2.7 and Python 3.6.