### PR TITLE
Fix settings variable in global scope js

### DIFF
--- a/octoprint_gcodesystemcommands/static/js/gcodesystemcommands.js
+++ b/octoprint_gcodesystemcommands/static/js/gcodesystemcommands.js
@@ -16,7 +16,7 @@ $(function() {
 
         self.onBeforeBinding = function () {
             self.global_settings.settings.plugins.gcodesystemcommands.command_definitions.subscribe(function() {
-                settings = self.global_settings.settings.plugins.gcodesystemcommands;
+                var settings = self.global_settings.settings.plugins.gcodesystemcommands;
                 self.command_definitions(settings.command_definitions.slice(0));            
             });
             self.global_settings.settings.plugins.gcodesystemcommands.command_definitions.valueHasMutated();


### PR DESCRIPTION
The settings variable in the command_definitions subscription callback in onBeforeBinding is being defined as a global variable and it probably should not be.

This PR makes it a local variable. 

After testing the change, the plugin is working as before.

<details>
  <summary>Some background as to why I found this</summary>
  
I was looking into this issue (https://github.com/j7126/OctoPrint-Dashboard/issues/282), and a user reported that this issue is a conflict with OctoPrint-GCodeSystemCommands. After looking into the issue it seems that it was being caused by this global `settings` variable being referenced when the local `settings` variable on the dashboard side was undefined. I have fixed the issue on the dashboard side, however it is probably a good idea to fix this as well. 
  
</details>