### PR TITLE
Octoprint 2.0.0 fixes

### DIFF
--- a/octoprint_gcodesystemcommands/__init__.py
+++ b/octoprint_gcodesystemcommands/__init__.py
@@ -3,21 +3,24 @@ from __future__ import absolute_import
 
 __author__ = "Shawn Bruce <kantlivelong@gmail.com>"
 __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agpl.html"
-__copyright__ = "Copyright (C) 2017 Shawn Bruce - Released under terms of the AGPLv3 License"
+__copyright__ = (
+    "Copyright (C) 2017 Shawn Bruce - Released under terms of the AGPLv3 License"
+)
 
 import octoprint.plugin
 import sys
 import subprocess
 import re
 
-class GCodeSystemCommands(octoprint.plugin.StartupPlugin,
-                          octoprint.plugin.TemplatePlugin,
-                          octoprint.plugin.AssetPlugin,
-                          octoprint.plugin.SettingsPlugin):
 
+class GCodeSystemCommands(
+    octoprint.plugin.StartupPlugin,
+    octoprint.plugin.TemplatePlugin,
+    octoprint.plugin.AssetPlugin,
+    octoprint.plugin.SettingsPlugin,
+):
     def __init__(self):
         self.command_definitions = {}
-
 
     def on_settings_initialized(self):
         self.reload_command_definitions()
@@ -29,19 +32,21 @@ class GCodeSystemCommands(octoprint.plugin.StartupPlugin,
         self._logger.debug("command_definitions: %s" % command_definitions_tmp)
 
         for definition in command_definitions_tmp:
-            cmd_id = definition['id']
-            cmd_line = definition['command']
+            cmd_id = definition["id"]
+            cmd_line = definition["command"]
             self.command_definitions[cmd_id] = cmd_line
             self._logger.info("Add command definition OCTO%s = %s" % (cmd_id, cmd_line))
 
-    def hook_gcode_sending(self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs):
+    def hook_gcode_sending(
+        self, comm_instance, phase, cmd, cmd_type, gcode, *args, **kwargs
+    ):
         if gcode:
             return
 
-        if cmd[:4] != 'OCTO':
+        if cmd[:4] != "OCTO":
             return
 
-        match = re.search(r'^(OCTO[0-9]+)(?:\s(.*))?$', cmd)
+        match = re.search(r"^(OCTO[0-9]+)(?:\s(.*))?$", cmd)
         if match is None:
             return
 
@@ -55,18 +60,26 @@ class GCodeSystemCommands(octoprint.plugin.StartupPlugin,
             comm_instance._log("Return(GCodeSystemCommands): undefined")
             return (None,)
 
-        self._logger.debug("Command ID=%s, Line=%s, Args=%s" % (cmd_id, cmd_line, cmd_args))
+        self._logger.debug(
+            "Command ID=%s, Line=%s, Args=%s" % (cmd_id, cmd_line, cmd_args)
+        )
 
         self._logger.info("Executing command ID: %s" % cmd_id)
         comm_instance._log("Exec(GCodeSystemCommands): OCTO%s" % cmd_id)
 
         cmd_env = {}
-        cmd_env['OCTOPRINT_GCODESYSTEMCOMMAND_ID'] = str(cmd_id)
-        cmd_env['OCTOPRINT_GCODESYSTEMCOMMAND_ARGS'] = str(cmd_args) if cmd_args else ''
-        cmd_env['OCTOPRINT_GCODESYSTEMCOMMAND_LINE'] = str(cmd)
+        cmd_env["OCTOPRINT_GCODESYSTEMCOMMAND_ID"] = str(cmd_id)
+        cmd_env["OCTOPRINT_GCODESYSTEMCOMMAND_ARGS"] = str(cmd_args) if cmd_args else ""
+        cmd_env["OCTOPRINT_GCODESYSTEMCOMMAND_LINE"] = str(cmd)
 
         try:
-            p = subprocess.Popen(cmd_line, env=cmd_env, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, shell=True)
+            p = subprocess.Popen(
+                cmd_line,
+                env=cmd_env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                shell=True,
+            )
             output = p.communicate()[0]
             r = p.returncode
         except:
@@ -74,66 +87,56 @@ class GCodeSystemCommands(octoprint.plugin.StartupPlugin,
             self._logger.exception("Error executing command ID %s: %s" % (cmd_id, e))
             return (None,)
 
-        self._logger.debug("Command ID %s returned: %s, output=%s" % (cmd_id, r, output))
+        self._logger.debug(
+            "Command ID %s returned: %s, output=%s" % (cmd_id, r, output)
+        )
         self._logger.info("Command ID %s returned: %s" % (cmd_id, r))
 
         if r == 0:
-            status = 'ok'
+            status = "ok"
         else:
-            status = 'error'
+            status = "error"
 
         comm_instance._log("Return(GCodeSystemCommands): %s" % status)
 
         return (None,)
 
     def get_settings_defaults(self):
-        return dict(
-            command_definitions = []
-        )
+        return dict(command_definitions=[])
 
     def get_settings_restricted_paths(self):
         return dict(admin=[["command_definitions"]])
-        
+
     def on_settings_save(self, data):
         octoprint.plugin.SettingsPlugin.on_settings_save(self, data)
         self.reload_command_definitions()
 
     def get_template_configs(self):
-        return [
-            dict(type="settings", custom_bindings=True)
-        ]
+        return [dict(type="settings", custom_bindings=True)]
 
     def get_assets(self):
-        return {
-            "js": ["js/gcodesystemcommands.js"]
-        } 
+        return {"js": ["js/gcodesystemcommands.js"]}
 
     def get_update_information(self):
         return dict(
             gcodesystemcommands=dict(
                 displayName="GCode System Commands",
                 displayVersion=self._plugin_version,
-
                 # version check: github repository
                 type="github_release",
                 user="kantlivelong",
                 repo="OctoPrint-GCodeSystemCommands",
                 current=self._plugin_version,
-
                 # update method: pip w/ dependency links
-                pip="https://github.com/kantlivelong/OctoPrint-GCodeSystemCommands/archive/{target_version}.zip"
+                pip="https://github.com/kantlivelong/OctoPrint-GCodeSystemCommands/archive/{target_version}.zip",
             )
         )
 
+
 __plugin_name__ = "GCODE System Commands"
 __plugin_pythoncompat__ = ">=2.7,<4"
-
-def __plugin_load__():
-    global __plugin_implementation__
-    __plugin_implementation__ = GCodeSystemCommands()
-
-    global __plugin_hooks__
-    __plugin_hooks__ = {
-        "octoprint.comm.protocol.gcode.sending": __plugin_implementation__.hook_gcode_sending,
-        "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information
-    }
+__plugin_implementation__ = GCodeSystemCommands()
+__plugin_hooks__ = {
+    "octoprint.comm.protocol.gcode.sending": __plugin_implementation__.hook_gcode_sending,
+    "octoprint.plugin.softwareupdate.check_config": __plugin_implementation__.get_update_information,
+}

--- a/octoprint_gcodesystemcommands/__init__.py
+++ b/octoprint_gcodesystemcommands/__init__.py
@@ -6,8 +6,6 @@ __license__ = "GNU Affero General Public License http://www.gnu.org/licenses/agp
 __copyright__ = "Copyright (C) 2017 Shawn Bruce - Released under terms of the AGPLv3 License"
 
 import octoprint.plugin
-import time
-import os
 import sys
 import subprocess
 import re

--- a/octoprint_gcodesystemcommands/__init__.py
+++ b/octoprint_gcodesystemcommands/__init__.py
@@ -95,17 +95,6 @@ class GCodeSystemCommands(octoprint.plugin.StartupPlugin,
 
     def get_settings_restricted_paths(self):
         return dict(admin=[["command_definitions"]])
-
-    def on_settings_load(self):
-        data = octoprint.plugin.SettingsPlugin.on_settings_load(self)
-
-        # only return our restricted settings to admin users - this is only needed for OctoPrint <= 1.2.16
-        restricted = ("command_definitions")
-        for r in restricted:
-            if r in data and (current_user is None or current_user.is_anonymous() or not current_user.is_admin()):
-                data[r] = None
-
-        return data
         
     def on_settings_save(self, data):
         octoprint.plugin.SettingsPlugin.on_settings_save(self, data)


### PR DESCRIPTION
Hi, I'm an active contributor to OctoPrint core. I helped ship [OctoPrint 2.0.0rc1](https://github.com/OctoPrint/OctoPrint/releases/tag/2.0.0rc1) and I'm now helping plugins stay compatible with the new and upcoming OctoPrint releases, which is why you're receiving this PR.

---

Before submitting please make sure you have ticked all points on this checklist:

  * [x] Your PR targets the devel branch.
  * [x] Your PR was opened from a custom branch on your repository (no PRs from your version of master or devel please)
  * [x] Your PR only contains relevant changes: no unrelated files, no dead code, ideally only one commit - rebase your PR if necessary!
  * [x] Your changes follow the existing coding style.
  * [x] You have tested your changes (please state how!)

Feel free to delete all this help text, then describe your PR further. You may use the template provided below to do that. The more details the better!

---

#### What does this PR do and why is it necessary?

This PR fixes the compatibility issues preventing this plugin from being installed on OctoPrint 2.0.0rc1.

In particular:

- Removes the use of `current_user.is_admin()`, which no longer exists in OctoPrint 2.0.0 ([ref](https://docs.octoprint.org/en/dev/plugins/migration_2_0_0.html#changes-in-octoprint-access-users)). It was only used as a failsafe for very old OctoPrint versions that virtually no one uses anymore, so I simply removed its usage entirely.
- Implements `TemplatePlugin` autoescape ([ref](https://docs.octoprint.org/en/main/plugins/mixins.html#octoprint.plugin.TemplatePlugin.is_template_autoescaped)).

Minor improvements are also applied, such as removal of unused imports and formatting with Ruff.

#### How was it tested? How can it be tested by the reviewer?

I tested the installation on both OctoPrint 2.0.0rc1 and the latest stable release 1.11.7, and everything appears to work correctly.

#### Any background context you want to provide?

#### What are the relevant tickets if any?

#### Screenshots (if appropriate)

#### Further notes

